### PR TITLE
Extend track quality flags in packed candidates:

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -135,7 +135,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="10">
+  <class name="pat::PackedCandidate" ClassVersion="11">
+    <version ClassVersion="11" checksum="3135186025"/>
     <version ClassVersion="10" checksum="572957881"/>
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />


### PR DESCRIPTION
- add one bit for track highPurity flag
- add two bits for missing inner hits
