### PR TITLE
fix include guard to a more proper name

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -1,5 +1,5 @@
-#ifndef __AnalysisDataFormats_CMGTools_PackedCandidate_h__
-#define __AnalysisDataFormats_CMGTools_PackedCandidate_h__
+#ifndef __DataFormats_PatCandidates_PackedCandidate_h__
+#define __DataFormats_PatCandidates_PackedCandidate_h__
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"


### PR DESCRIPTION
it shouldn't be CMGTools in the version in PatCandidates
