### PR TITLE
Micro from700 reduced egamma

### DIFF
--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -163,6 +163,7 @@ class GsfElectron : public RecoCandidate
 
     // accessors
     virtual GsfElectronCoreRef core() const ;
+    void setCore(const reco::GsfElectronCoreRef &core) { core_ = core; }
 
     // forward core methods
     virtual SuperClusterRef superCluster() const { return core()->superCluster() ; }

--- a/DataFormats/EgammaCandidates/interface/Photon.h
+++ b/DataFormats/EgammaCandidates/interface/Photon.h
@@ -47,6 +47,8 @@ namespace reco {
 
     /// returns a reference to the core photon object
     reco::PhotonCoreRef photonCore() const { return photonCore_;}
+    void setPhotonCore(const reco::PhotonCoreRef &photonCore) { photonCore_ = photonCore; }
+    
     //
     /// Retrieve photonCore attributes
     //

--- a/DataFormats/EgammaCandidates/interface/PhotonCore.h
+++ b/DataFormats/EgammaCandidates/interface/PhotonCore.h
@@ -76,6 +76,9 @@ namespace reco {
     /// get vector of references to one leg Conversion's
     reco::ConversionRefVector conversionsOneLeg() const {return conversionsOneLeg_;} 
 
+    void setConversions(const reco::ConversionRefVector &conversions) { conversions_ = conversions; }
+    void setConversionsOneLeg(const reco::ConversionRefVector &conversions) { conversionsOneLeg_ = conversions; }
+    
     /// get reference to electron seed if existing
     reco::ElectronSeedRefVector electronPixelSeeds() const {return electronSeed_;}
     bool isPFlowPhoton() const {return isPFlowPhoton_;} 

--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -104,6 +104,9 @@ namespace reco {
     //(re)-set preshower clusters
     void setPreshowerClusters(const CaloClusterPtrVector &clusters) { preshowerClusters_ = clusters; }
     
+    //clear hits and fractions vector (for slimming)
+    void clearHitsAndFractions() { hitsAndFractions_.clear(); }
+    
     /// add reference to constituent BasicCluster
     void addCluster( const CaloClusterPtr & r ) { 
       clusters_.push_back( r ); 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -14,15 +14,56 @@ def miniAOD_customizeCommon(process):
     process.patMuons.embedTpfmsMuon = False   # no, use best track
     process.patMuons.embedDytMuon   = False   # no, use best track
     #
-    process.patElectrons.embedPflowSuperCluster         = False
-    process.patElectrons.embedPflowBasicClusters        = False
-    process.patElectrons.embedPflowPreshowerClusters    = False
+    # disable embedding of electron and photon associated objects already stored by the ReducedEGProducer
+    process.patElectrons.embedGsfElectronCore = False  ## process.patElectrons.embed in AOD externally stored gsf electron core
+    process.patElectrons.embedSuperCluster    = False  ## process.patElectrons.embed in AOD externally stored supercluster
+    process.patElectrons.embedPflowSuperCluster         = False  ## process.patElectrons.embed in AOD externally stored supercluster
+    process.patElectrons.embedSeedCluster               = False  ## process.patElectrons.embed in AOD externally stored the electron's seedcluster 
+    process.patElectrons.embedBasicClusters             = False  ## process.patElectrons.embed in AOD externally stored the electron's basic clusters 
+    process.patElectrons.embedPreshowerClusters         = False  ## process.patElectrons.embed in AOD externally stored the electron's preshower clusters 
+    process.patElectrons.embedPflowBasicClusters        = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow basic clusters 
+    process.patElectrons.embedPflowPreshowerClusters    = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow preshower clusters 
+    process.patElectrons.embedRecHits         = False  ## process.patElectrons.embed in AOD externally stored the RecHits - can be called from the PATElectronProducer 
+    process.patElectrons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.patElectrons.electronIDSources = cms.PSet(
+            # configure many IDs as InputTag <someName> = <someTag> you
+            # can comment out those you don't want to save some disk space
+            eidRobustLoose      = cms.InputTag("reducedEgamma","eidRobustLoose"),
+            eidRobustTight      = cms.InputTag("reducedEgamma","eidRobustTight"),
+            eidLoose            = cms.InputTag("reducedEgamma","eidLoose"),
+            eidTight            = cms.InputTag("reducedEgamma","eidTight"),
+            eidRobustHighEnergy = cms.InputTag("reducedEgamma","eidRobustHighEnergy"),
+        )
+    process.elPFIsoDepositCharged.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositChargedAll.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositNeutral.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositGamma.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositPU.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    #
+    process.patPhotons.embedSuperCluster = False ## whether to process.patPhotons.embed in AOD externally stored supercluster
+    process.patPhotons.embedSeedCluster               = False  ## process.patPhotons.embed in AOD externally stored the photon's seedcluster 
+    process.patPhotons.embedBasicClusters             = False  ## process.patPhotons.embed in AOD externally stored the photon's basic clusters 
+    process.patPhotons.embedPreshowerClusters         = False  ## process.patPhotons.embed in AOD externally stored the photon's preshower clusters 
+    process.patPhotons.embedRecHits         = False  ## process.patPhotons.embed in AOD externally stored the RecHits - can be called from the PATPhotonProducer 
+    process.patPhotons.photonSource = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.patPhotons.photonIDSources = cms.PSet(
+                PhotonCutBasedIDLoose = cms.InputTag('reducedEgamma',
+                                                      'PhotonCutBasedIDLoose'),
+                PhotonCutBasedIDTight = cms.InputTag('reducedEgamma',
+                                                      'PhotonCutBasedIDTight')
+              )
+
+    process.phPFIsoDepositCharged.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositChargedAll.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositNeutral.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositGamma.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositPU.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
     #
     process.selectedPatJets.cut = cms.string("pt > 10")
     process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))") 
     process.selectedPatElectrons.cut = cms.string("") 
     process.selectedPatTaus.cut = cms.string("pt > 20 && tauID('decayModeFinding')> 0.5")
-    process.selectedPatPhotons.cut = cms.string("pt > 15 && hadTowOverEm()<0.15 ")
+    process.selectedPatPhotons.cut = cms.string("")
     #
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
     #
@@ -59,7 +100,9 @@ def miniAOD_customizeCommon(process):
 def miniAOD_customizeMC(process):
     process.muonMatch.matched = "prunedGenParticles"
     process.electronMatch.matched = "prunedGenParticles"
+    process.electronMatch.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     process.photonMatch.matched = "prunedGenParticles"
+    process.photonMatch.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
     process.tauMatch.matched = "prunedGenParticles"
     process.patJetPartonMatch.matched = "prunedGenParticles"
     process.patJetGenJetMatch.matched = "slimmedGenJets"

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -3,19 +3,19 @@ import FWCore.ParameterSet.Config as cms
 slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    src = cms.InputTag("selectedPatElectrons"),
    dropSuperCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropBasicClusters = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPFlowClusters = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropPreshowerClusters = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropSeedCluster = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropRecHits = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropCorrections = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropExtrapolations  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropClassifications  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropBasicClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPFlowClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropCorrections = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropIsolations = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropShapes = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropExtrapolations  = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropClassifications  = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
    linkToPackedPFCandidates = cms.bool(True),
-   recoToPFMap = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
+   recoToPFMap = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap"),
    packedPFCandidates = cms.InputTag("packedPFCandidates"), 
-   saveNonZSClusterShapes = cms.string("pt > 5"), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
+   saveNonZSClusterShapes = cms.string(""), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedElectrons_cfi.py
@@ -8,14 +8,14 @@ slimmedElectrons = cms.EDProducer("PATElectronSlimmer",
    dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
    dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
    dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropCorrections = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropIsolations = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropShapes = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropExtrapolations  = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-   dropClassifications  = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropCorrections = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropIsolations = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropShapes = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropExtrapolations  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
+   dropClassifications  = cms.string("pt < 5"), # you can put a cut to slim selectively, e.g. pt < 10
    linkToPackedPFCandidates = cms.bool(True),
    recoToPFMap = cms.InputTag("reducedEgamma","reducedGsfElectronPfCandMap"),
    packedPFCandidates = cms.InputTag("packedPFCandidates"), 
-   saveNonZSClusterShapes = cms.string(""), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
+   saveNonZSClusterShapes = cms.string("pt > 5"), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
 )
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
@@ -10,5 +10,5 @@ slimmedPhotons = cms.EDProducer("PATPhotonSlimmer",
     linkToPackedPFCandidates = cms.bool(True),
     recoToPFMap = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"),
     packedPFCandidates = cms.InputTag("packedPFCandidates"),
-    saveNonZSClusterShapes = cms.string(""), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
+    saveNonZSClusterShapes = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedPhotons_cfi.py
@@ -3,12 +3,12 @@ import FWCore.ParameterSet.Config as cms
 slimmedPhotons = cms.EDProducer("PATPhotonSlimmer",
     src = cms.InputTag("selectedPatPhotons"),
     dropSuperCluster = cms.string("0"), # always keep SC?   # ! (r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # you can put a cut to slim selectively, e.g. pt < 10
-    dropBasicClusters = cms.string("! (r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # you can put a cut to slim selectively, e.g. pt < 10
-    dropPreshowerClusters = cms.string("! (r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # you can put a cut to slim selectively, e.g. pt < 10
+    dropBasicClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
+    dropPreshowerClusters = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
     dropSeedCluster = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
-    dropRecHits = cms.string("! (r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # you can put a cut to slim selectively, e.g. pt < 10
+    dropRecHits = cms.string("0"), # you can put a cut to slim selectively, e.g. pt < 10
     linkToPackedPFCandidates = cms.bool(True),
-    recoToPFMap = cms.InputTag("particleBasedIsolation","gedPhotons"),
+    recoToPFMap = cms.InputTag("reducedEgamma","reducedPhotonPfCandMap"),
     packedPFCandidates = cms.InputTag("packedPFCandidates"),
-    saveNonZSClusterShapes = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
+    saveNonZSClusterShapes = cms.string(""), # save additional user floats: (sigmaIetaIeta,sigmaIphiIphi,sigmaIetaIphi,r9,e1x5_over_e5x5)_NoZS 
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -27,6 +27,14 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedSecondaryVertices*_*_*',
         ## add extra METs
 
+        'keep recoPhotonCores_reducedEgamma_*_*',
+        'keep recoGsfElectronCores_reducedEgamma_*_*',
+        'keep recoConversions_reducedEgamma_*_*',
+        'keep recoSuperClusters_reducedEgamma_*_*',
+        'keep recoCaloClusters_reducedEgamma_*_*',
+        'keep EcalRecHitsSorted_reducedEgamma_*_*',
+        
+
         'drop *_*_caloTowers_*',
         'drop *_*_pfCandidates_*',
         'drop *_*_genJets_*',

--- a/PhysicsTools/PatAlgos/test/miniAOD/patTuple_mini.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/patTuple_mini.py
@@ -4,6 +4,7 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import cms, process
 process.options.allowUnscheduled = cms.untracked.bool(True)
 #process.Tracer = cms.Service("Tracer")
 
+process.load("RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi")
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 

--- a/PhysicsTools/PatAlgos/test/miniAOD/patTuple_mini_data.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/patTuple_mini_data.py
@@ -4,6 +4,7 @@ from PhysicsTools.PatAlgos.patTemplate_cfg import cms, process
 process.options.allowUnscheduled = cms.untracked.bool(True)
 #process.Tracer = cms.Service("Tracer")
 
+process.load("RecoEgamma.EgammaPhotonProducers.reducedEgamma_cfi")
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -1,0 +1,104 @@
+#ifndef RecoEgamma_EgammaPhotonProducers_ReducedEGProducer_h
+#define RecoEgamma_EgammaPhotonProducers_ReducedEGProducer_h
+/** \class ReducedEGProducer
+ **  
+ **  Select subset of electrons and photons from input collections and
+ **  produced consistently relinked output collections including
+ **  associated SuperClusters, CaloClusters and ecal RecHits
+ **
+ **  \author J.Bendavid (CERN)
+ **
+ ***/
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/EgammaReco/interface/BasicCluster.h"
+#include "DataFormats/EgammaReco/interface/SuperCluster.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonCore.h"
+#include "DataFormats/EgammaReco/interface/BasicClusterShapeAssociation.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
+#include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/PfBlockBasedIsolation.h"
+#include "RecoCaloTools/MetaCollections/interface/CaloRecHitMetaCollections.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
+#include "RecoEgamma/PhotonIdentification/interface/PFPhotonIsolationCalculator.h"
+#include "RecoEgamma/PhotonIdentification/interface/PhotonIsolationCalculator.h"
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
+#include "RecoEgamma/PhotonIdentification/interface/PhotonMIPHaloTagger.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
+#include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h" 
+#include "RecoEgamma/EgammaPhotonAlgos/interface/PhotonEnergyCorrector.h"
+
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+
+
+// ReducedEGProducer inherits from EDProducer, so it can be a module:
+class ReducedEGProducer : public edm::EDProducer {
+
+ public:
+
+  ReducedEGProducer (const edm::ParameterSet& ps);
+  ~ReducedEGProducer();
+
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+
+ private: 
+  
+ //tokens for input collections
+ edm::EDGetTokenT<reco::PhotonCollection> photonT_;
+ edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_; 
+ edm::EDGetTokenT<reco::ConversionCollection> conversionT_;
+ edm::EDGetTokenT<reco::ConversionCollection> singleConversionT_;
+ 
+ edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHits_;
+ edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
+ edm::EDGetTokenT<EcalRecHitCollection> preshowerEcalHits_;
+ 
+ edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMapT_;
+ edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMapT_;
+ 
+ std::vector<edm::EDGetTokenT<edm::ValueMap<bool> > > photonIdTs_;
+ std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > gsfElectronIdTs_;
+ 
+ //names for output collections
+ std::string outPhotons_;
+ std::string outPhotonCores_;
+ std::string outGsfElectrons_;
+ std::string outGsfElectronCores_;
+ std::string outConversions_;
+ std::string outSingleConversions_;
+ std::string outSuperClusters_;
+ std::string outEBEEClusters_;
+ std::string outESClusters_;
+ std::string outEBRecHits_;
+ std::string outEERecHits_;
+ std::string outESRecHits_;
+ std::string outPhotonPfCandMap_;
+ std::string outGsfElectronPfCandMap_;
+ std::vector<std::string> outPhotonIds_;
+ std::vector<std::string> outGsfElectronIds_;
+ 
+ StringCutObjectSelector<reco::Photon> keepPhotonSel_;
+ StringCutObjectSelector<reco::Photon> relinkPhotonSel_;
+ StringCutObjectSelector<reco::GsfElectron> keepGsfElectronSel_;
+ StringCutObjectSelector<reco::GsfElectron> relinkGsfElectronSel_; 
+ 
+ 
+
+};
+#endif
+
+

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -92,8 +92,10 @@ class ReducedEGProducer : public edm::EDProducer {
  std::vector<std::string> outGsfElectronIds_;
  
  StringCutObjectSelector<reco::Photon> keepPhotonSel_;
+ StringCutObjectSelector<reco::Photon> slimRelinkPhotonSel_; 
  StringCutObjectSelector<reco::Photon> relinkPhotonSel_;
  StringCutObjectSelector<reco::GsfElectron> keepGsfElectronSel_;
+ StringCutObjectSelector<reco::GsfElectron> slimRelinkGsfElectronSel_;
  StringCutObjectSelector<reco::GsfElectron> relinkGsfElectronSel_; 
  
  

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -1,0 +1,43 @@
+import FWCore.ParameterSet.Config as cms
+
+reducedEgamma = cms.EDProducer("ReducedEGProducer",
+  keepPhotons = cms.string("pt > 14 && hadTowOverEm()<0.15"),
+  relinkPhotons = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"),
+  keepGsfElectrons = cms.string(""),
+  relinkGsfElectrons = cms.string("pt>5"),
+  photons = cms.InputTag("gedPhotons"),
+  gsfElectrons = cms.InputTag("gedGsfElectrons"),
+  conversions = cms.InputTag("allConversions"),
+  singleConversions = cms.InputTag("gedPhotonCore"),
+  barrelEcalHits = cms.InputTag("reducedEcalRecHitsEB"),
+  endcapEcalHits = cms.InputTag("reducedEcalRecHitsEE"),
+  preshowerEcalHits = cms.InputTag("reducedEcalRecHitsES"),
+  photonsPFValMap = cms.InputTag("particleBasedIsolation","gedPhotons"),
+  gsfElectronsPFValMap = cms.InputTag("particleBasedIsolation","gedGsfElectrons"),
+  photonIDSources = cms.VInputTag(
+    cms.InputTag("PhotonIDProdGED","PhotonCutBasedIDLoose"),
+    cms.InputTag("PhotonIDProdGED","PhotonCutBasedIDLooseEM"),    
+    cms.InputTag("PhotonIDProdGED","PhotonCutBasedIDTight")
+  ),
+  photonIDOutput = cms.vstring(
+    "PhotonCutBasedIDLoose",
+    "PhotonCutBasedIDLooseEM",
+    "PhotonCutBasedIDTight",
+  ),
+  gsfElectronIDSources = cms.VInputTag(
+    cms.InputTag("eidLoose"),
+    cms.InputTag("eidRobustHighEnergy"),
+    cms.InputTag("eidRobustLoose"),
+    cms.InputTag("eidRobustTight"),
+    cms.InputTag("eidTight"),
+  ),
+  gsfElectronIDOutput = cms.vstring(
+    "eidLoose",
+    "eidRobustHighEnergy",
+    "eidRobustLoose",
+    "eidRobustTight",
+    "eidTight",
+  ),
+)
+
+

--- a/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/reducedEgamma_cfi.py
@@ -1,10 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 reducedEgamma = cms.EDProducer("ReducedEGProducer",
-  keepPhotons = cms.string("pt > 14 && hadTowOverEm()<0.15"),
-  relinkPhotons = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"),
-  keepGsfElectrons = cms.string(""),
-  relinkGsfElectrons = cms.string("pt>5"),
+  keepPhotons = cms.string("pt > 14 && hadTowOverEm()<0.15"), #keep in output
+  slimRelinkPhotons = cms.string("pt > 14 && hadTowOverEm()<0.15"), #keep only slimmed SuperCluster plus seed cluster
+  relinkPhotons = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"), #keep all associated clusters/rechits/conversions
+  keepGsfElectrons = cms.string(""), #keep in output
+  slimRelinkGsfElectrons = cms.string(""), #keep only slimmed SuperCluster plus seed cluster
+  relinkGsfElectrons = cms.string("pt>5"), #keep all associated clusters/rechits/conversions
   photons = cms.InputTag("gedPhotons"),
   gsfElectrons = cms.InputTag("gedGsfElectrons"),
   conversions = cms.InputTag("allConversions"),

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -1,0 +1,607 @@
+#include <iostream>
+#include <vector>
+#include <memory>
+
+// Framework
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "CommonTools/Utils/interface/StringToEnumValue.h"
+
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
+#include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
+
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/EgammaReco/interface/ClusterShape.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonCore.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtra.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
+
+
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "RecoCaloTools/Selectors/interface/CaloConeSelector.h"
+
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
+#include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
+
+#include "RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
+
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
+#include "RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.h"
+#include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
+
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
+  keepPhotonSel_(config.getParameter<std::string>("keepPhotons")),
+  relinkPhotonSel_(config.getParameter<std::string>("relinkPhotons")),
+  keepGsfElectronSel_(config.getParameter<std::string>("keepGsfElectrons")),
+  relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons"))
+{
+
+
+  photonT_ = consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"));
+  gsfElectronT_ = consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"));
+  conversionT_ = consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"));
+  singleConversionT_ = consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("singleConversions"));
+  
+  barrelEcalHits_   = 
+    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"));
+  endcapEcalHits_   = 
+    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalHits"));
+  preshowerEcalHits_   = 
+    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("preshowerEcalHits"));
+
+  photonPfCandMapT_ = consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("photonsPFValMap"));
+  gsfElectronPfCandMapT_ = consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("gsfElectronsPFValMap"));
+
+  std::vector<edm::InputTag> photonidinputs(config.getParameter<std::vector<edm::InputTag> >("photonIDSources"));
+  for (edm::InputTag &tag : photonidinputs) {
+    photonIdTs_.emplace_back(consumes<edm::ValueMap<bool> >(tag));
+  }
+  
+  std::vector<edm::InputTag> gsfelectronidinputs(config.getParameter<std::vector<edm::InputTag> >("gsfElectronIDSources"));
+  for (edm::InputTag &tag : gsfelectronidinputs) {
+    gsfElectronIdTs_.emplace_back(consumes<edm::ValueMap<float> >(tag));
+  }  
+  
+  //output collections    
+  outPhotons_ = "reducedGedPhotons";
+  outPhotonCores_ = "reducedGedPhotonCores";
+  outGsfElectrons_ = "reducedGedGsfElectrons";
+  outGsfElectronCores_ = "reducedGedGsfElectronCores";
+  outConversions_ = "reducedConversions";
+  outSingleConversions_ = "reducedSingleLegConversions";
+  outSuperClusters_ = "reducedSuperClusters";
+  outEBEEClusters_ = "reducedEBEEClusters";
+  outESClusters_ = "reducedESClusters";
+  outEBRecHits_ = "reducedEBRecHits";
+  outEERecHits_ = "reducedEERecHits";
+  outESRecHits_ = "reducedESRecHits";
+  outPhotonPfCandMap_ = "reducedPhotonPfCandMap";
+  outGsfElectronPfCandMap_ = "reducedGsfElectronPfCandMap";
+  outPhotonIds_ = config.getParameter<std::vector<std::string> >("photonIDOutput");
+  outGsfElectronIds_ = config.getParameter<std::vector<std::string> >("gsfElectronIDOutput");
+  
+  
+  produces< reco::PhotonCollection >(outPhotons_);
+  produces< reco::PhotonCoreCollection >(outPhotonCores_);
+  produces< reco::GsfElectronCollection >(outGsfElectrons_);
+  produces< reco::GsfElectronCoreCollection >(outGsfElectronCores_);
+  produces< reco::ConversionCollection >(outConversions_);
+  produces< reco::ConversionCollection >(outSingleConversions_);
+  produces< reco::SuperClusterCollection >(outSuperClusters_);  
+  produces< reco::CaloClusterCollection >(outEBEEClusters_);
+  produces< reco::CaloClusterCollection >(outESClusters_);
+  produces< EcalRecHitCollection >(outEBRecHits_);
+  produces< EcalRecHitCollection >(outEERecHits_);
+  produces< EcalRecHitCollection >(outESRecHits_);    
+  produces< edm::ValueMap<std::vector<reco::PFCandidateRef> > >(outPhotonPfCandMap_);    
+  produces< edm::ValueMap<std::vector<reco::PFCandidateRef> > >(outGsfElectronPfCandMap_);   
+  for (const std::string &outid : outPhotonIds_) {
+    produces< edm::ValueMap<bool> >(outid);   
+  }
+  for (const std::string &outid : outGsfElectronIds_) {
+    produces< edm::ValueMap<float> >(outid);   
+  }  
+
+}
+
+ReducedEGProducer::~ReducedEGProducer() 
+{
+}
+
+
+
+
+void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
+
+  //get input collections
+  
+  
+  edm::Handle<reco::PhotonCollection> photonHandle;
+  theEvent.getByToken(photonT_, photonHandle);
+
+  edm::Handle<reco::GsfElectronCollection> gsfElectronHandle;
+  theEvent.getByToken(gsfElectronT_, gsfElectronHandle);  
+  
+  edm::Handle<reco::ConversionCollection> conversionHandle;
+  theEvent.getByToken(conversionT_, conversionHandle);  
+
+  edm::Handle<reco::ConversionCollection> singleConversionHandle;
+  theEvent.getByToken(singleConversionT_, singleConversionHandle);    
+  
+  edm::Handle<EcalRecHitCollection> barrelHitHandle;
+  theEvent.getByToken(barrelEcalHits_, barrelHitHandle);  
+  
+  edm::Handle<EcalRecHitCollection> endcapHitHandle;
+  theEvent.getByToken(endcapEcalHits_, endcapHitHandle);
+
+  edm::Handle<EcalRecHitCollection> preshowerHitHandle;
+  theEvent.getByToken(preshowerEcalHits_, preshowerHitHandle);
+  
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMapHandle;
+  theEvent.getByToken(photonPfCandMapT_, photonPfCandMapHandle);  
+
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMapHandle;
+  theEvent.getByToken(gsfElectronPfCandMapT_, gsfElectronPfCandMapHandle);    
+  
+  std::vector<edm::Handle<edm::ValueMap<bool> > > photonIdHandles(photonIdTs_.size());
+  for (unsigned int itok=0; itok<photonIdTs_.size(); ++itok) {
+    theEvent.getByToken(photonIdTs_[itok],photonIdHandles[itok]);
+  }
+  
+  std::vector<edm::Handle<edm::ValueMap<float> > > gsfElectronIdHandles(gsfElectronIdTs_.size());
+  for (unsigned int itok=0; itok<gsfElectronIdTs_.size(); ++itok) {
+    theEvent.getByToken(gsfElectronIdTs_[itok],gsfElectronIdHandles[itok]);
+  }  
+  
+  edm::ESHandle<CaloTopology> theCaloTopology;
+  theEventSetup.get<CaloTopologyRecord>().get(theCaloTopology);  
+  const CaloTopology *caloTopology = & (*theCaloTopology);  
+  
+  //initialize output collections
+  std::auto_ptr<reco::PhotonCollection> photons(new reco::PhotonCollection);
+  std::auto_ptr<reco::PhotonCoreCollection> photonCores(new reco::PhotonCoreCollection);
+  std::auto_ptr<reco::GsfElectronCollection> gsfElectrons(new reco::GsfElectronCollection);
+  std::auto_ptr<reco::GsfElectronCoreCollection> gsfElectronCores(new reco::GsfElectronCoreCollection);
+  std::auto_ptr<reco::ConversionCollection> conversions(new reco::ConversionCollection);
+  std::auto_ptr<reco::ConversionCollection> singleConversions(new reco::ConversionCollection);
+  std::auto_ptr<reco::SuperClusterCollection> superClusters(new reco::SuperClusterCollection);
+  std::auto_ptr<reco::CaloClusterCollection> ebeeClusters(new reco::CaloClusterCollection);
+  std::auto_ptr<reco::CaloClusterCollection> esClusters(new reco::CaloClusterCollection);
+  std::auto_ptr<EcalRecHitCollection> ebRecHits(new EcalRecHitCollection);
+  std::auto_ptr<EcalRecHitCollection> eeRecHits(new EcalRecHitCollection);
+  std::auto_ptr<EcalRecHitCollection> esRecHits(new EcalRecHitCollection);
+  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMap(new edm::ValueMap<std::vector<reco::PFCandidateRef> >);
+  std::auto_ptr<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMap(new edm::ValueMap<std::vector<reco::PFCandidateRef> >);
+  
+  std::vector<std::auto_ptr<edm::ValueMap<bool> > > photonIds;
+  for (unsigned int iid=0; iid<photonIdHandles.size(); ++iid) {
+    photonIds.emplace_back(new edm::ValueMap<bool>);
+  }
+    
+  std::vector<std::auto_ptr<edm::ValueMap<float> > > gsfElectronIds;
+  for (unsigned int iid=0; iid<gsfElectronIdHandles.size(); ++iid) {
+    gsfElectronIds.emplace_back(new edm::ValueMap<float>);
+  }
+  
+  //maps to collection indices of output objects
+  std::map<reco::PhotonCoreRef, unsigned int> photonCoreMap;
+  std::map<reco::GsfElectronCoreRef, unsigned int> gsfElectronCoreMap;
+  std::map<reco::ConversionRef, unsigned int> conversionMap;
+  std::map<reco::ConversionRef, unsigned int> singleConversionMap;
+  std::map<reco::SuperClusterRef, unsigned int> superClusterMap;
+  std::map<reco::CaloClusterPtr, unsigned int> ebeeClusterMap;
+  std::map<reco::CaloClusterPtr, unsigned int> esClusterMap;
+  std::set<DetId> rechitMap;
+  
+  //vectors for pfcandidate valuemaps
+  std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecPho;  
+  std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecEle;
+  
+  //vectors for id valuemaps
+  std::vector<std::vector<bool> > photonIdVals(photonIds.size());
+  std::vector<std::vector<float> > gsfElectronIdVals(gsfElectronIds.size());
+  
+  //loop over photons and fill maps
+  for (unsigned int ipho=0; ipho<photonHandle->size(); ++ipho) {
+    const reco::Photon &photon = (*photonHandle)[ipho];
+    
+    bool keep = keepPhotonSel_(photon);
+    if (!keep) continue;
+    
+    reco::PhotonRef photonref(photonHandle,ipho);
+    
+    photons->push_back(photon);
+    
+    //fill pf candidate value map vector
+    pfCandIsoPairVecPho.push_back((*photonPfCandMapHandle)[photonref]);
+
+    //fill photon id valuemap vectors
+    for (unsigned int iid=0; iid<photonIds.size(); ++iid) {
+      photonIdVals[iid].push_back( (*photonIdHandles[iid])[photonref] );
+    }    
+    
+    const reco::PhotonCoreRef &photonCore = photon.photonCore();
+    if (!photonCoreMap.count(photonCore)) {
+      photonCores->push_back(*photonCore);
+      photonCoreMap[photonCore] = photonCores->size() - 1;
+    }
+    
+    bool relink = relinkPhotonSel_(photon);    
+    if (!relink) continue;
+    
+    const reco::SuperClusterRef &superCluster = photon.superCluster();
+    if (!superClusterMap.count(superCluster)) {
+      superClusters->push_back(*superCluster);
+      superClusterMap[superCluster] = superClusters->size() - 1;
+    }
+    
+    const reco::ConversionRefVector &convrefs = photon.conversions();
+    for (const reco::ConversionRef &convref : convrefs) {
+      if (!conversionMap.count(convref)) {
+        conversions->push_back(*convref);
+        conversionMap[convref] = conversions->size() - 1;
+      }
+    }
+    
+    //explicitly references conversions
+    const reco::ConversionRefVector &singleconvrefs = photon.conversionsOneLeg();
+    for (const reco::ConversionRef &convref : singleconvrefs) {
+      if (!singleConversionMap.count(convref)) {
+        singleConversions->push_back(*convref);
+        singleConversionMap[convref] = singleConversions->size() - 1;
+      }
+    }    
+    
+  }
+  
+  //loop over electrons and fill maps
+  for (unsigned int iele = 0; iele<gsfElectronHandle->size(); ++iele) {
+    const reco::GsfElectron &gsfElectron = (*gsfElectronHandle)[iele];
+    
+    bool keep = keepGsfElectronSel_(gsfElectron);    
+    if (!keep) continue;
+    
+    reco::GsfElectronRef gsfElectronref(gsfElectronHandle,iele);
+    
+    gsfElectrons->push_back(gsfElectron);
+    pfCandIsoPairVecEle.push_back((*gsfElectronPfCandMapHandle)[gsfElectronref]);
+    
+    //fill electron id valuemap vectors
+    for (unsigned int iid=0; iid<gsfElectronIds.size(); ++iid) {
+      gsfElectronIdVals[iid].push_back( (*gsfElectronIdHandles[iid])[gsfElectronref] );
+    }    
+
+    const reco::GsfElectronCoreRef &gsfElectronCore = gsfElectron.core();
+    if (!gsfElectronCoreMap.count(gsfElectronCore)) {
+      gsfElectronCores->push_back(*gsfElectronCore);
+      gsfElectronCoreMap[gsfElectronCore] = gsfElectronCores->size() - 1;
+    }    
+    
+    bool relink = relinkGsfElectronSel_(gsfElectron);
+    if (!relink) continue;
+    
+    const reco::SuperClusterRef &superCluster = gsfElectron.superCluster();
+    if (!superClusterMap.count(superCluster)) {
+      superClusters->push_back(*superCluster);
+      superClusterMap[superCluster] = superClusters->size() - 1;
+    }
+    
+    //conversions matched by trackrefs
+    for (unsigned int iconv = 0; iconv<conversionHandle->size(); ++iconv) {
+      const reco::Conversion &conversion = (*conversionHandle)[iconv];
+      reco::ConversionRef convref(conversionHandle,iconv);
+      
+      bool matched = ConversionTools::matchesConversion(gsfElectron,conversion,true,true);
+      if (!matched) continue;
+      
+      if (!conversionMap.count(convref)) {
+        conversions->push_back(conversion);
+        conversionMap[convref] = conversions->size() - 1;
+      }
+      
+    }
+    
+    //single leg conversions matched by trackrefs
+    for (unsigned int iconv = 0; iconv<singleConversionHandle->size(); ++iconv) {
+      const reco::Conversion &conversion = (*singleConversionHandle)[iconv];
+      reco::ConversionRef convref(singleConversionHandle,iconv);
+      
+      bool matched = ConversionTools::matchesConversion(gsfElectron,conversion,true,true);
+      if (!matched) continue;
+      
+      if (!singleConversionMap.count(convref)) {
+        singleConversions->push_back(conversion);
+        singleConversionMap[convref] = singleConversions->size() - 1;
+      }
+      
+    }    
+    
+  }
+  
+  //loop over output SuperClusters and fill maps
+  for (const reco::SuperCluster &superCluster : *superClusters) {
+    if (!ebeeClusterMap.count(superCluster.seed())) {
+      ebeeClusters->push_back(*superCluster.seed());
+      ebeeClusterMap[superCluster.seed()] = ebeeClusters->size() - 1;
+    }
+    
+    for (const reco::CaloClusterPtr &cluster : superCluster.clusters()) {
+      if (!ebeeClusterMap.count(cluster)) {
+        ebeeClusters->push_back(*cluster);
+        ebeeClusterMap[cluster] = ebeeClusters->size() - 1;
+      }
+      for (std::pair<DetId,float> hitfrac : cluster->hitsAndFractions()) {
+        rechitMap.insert(hitfrac.first);
+      }
+      //make sure to also take all hits in the 5x5 around the max energy xtal
+      bool barrel = cluster->hitsAndFractions().front().first.subdetId()==EcalBarrel;
+      const EcalRecHitCollection *rhcol = barrel ? barrelHitHandle.product() : endcapHitHandle.product();
+      DetId seed = EcalClusterTools::getMaximum(*cluster, rhcol).first;
+      
+      std::vector<DetId> dets5x5 = (barrel) ? caloTopology->getSubdetectorTopology(DetId::Ecal,EcalBarrel)->getWindow(seed,5,5) : caloTopology->getSubdetectorTopology(DetId::Ecal,EcalEndcap)->getWindow(seed,5,5);
+      for (const DetId &detid : dets5x5) {
+        rechitMap.insert(detid);
+      }
+    }
+    for (const reco::CaloClusterPtr &cluster : superCluster.preshowerClusters()) {
+      if (!esClusterMap.count(cluster)) {
+        esClusters->push_back(*cluster);
+        esClusterMap[cluster] = esClusters->size() - 1;
+      }
+      for (std::pair<DetId,float> hitfrac : cluster->hitsAndFractions()) {
+        rechitMap.insert(hitfrac.first);
+      }      
+    }
+    
+    //conversions matched geometrically
+    for (unsigned int iconv = 0; iconv<conversionHandle->size(); ++iconv) {
+      const reco::Conversion &conversion = (*conversionHandle)[iconv];
+      reco::ConversionRef convref(conversionHandle,iconv);
+      
+      bool matched = ConversionTools::matchesConversion(superCluster,conversion,0.2);
+      if (!matched) continue;
+      
+      if (!conversionMap.count(convref)) {
+        conversions->push_back(conversion);
+        conversionMap[convref] = conversions->size() - 1;
+      }
+      
+    }
+    
+    //single leg conversions matched by trackrefs
+    for (unsigned int iconv = 0; iconv<singleConversionHandle->size(); ++iconv) {
+      const reco::Conversion &conversion = (*singleConversionHandle)[iconv];
+      reco::ConversionRef convref(singleConversionHandle,iconv);
+      
+      bool matched = ConversionTools::matchesConversion(superCluster,conversion,0.2);
+      if (!matched) continue;
+      
+      if (!singleConversionMap.count(convref)) {
+        singleConversions->push_back(conversion);
+        singleConversionMap[convref] = singleConversions->size() - 1;
+      }
+      
+    }
+    
+  }
+  
+  //now finalize and add to the event collections in "reverse" order
+  
+  //rechits (fill output collections of rechits to be stored)
+  for (const EcalRecHit &rechit : *barrelHitHandle) {
+    if (rechitMap.count(rechit.detid())) {
+      ebRecHits->push_back(rechit);
+    }
+  }
+  
+  for (const EcalRecHit &rechit : *endcapHitHandle) {
+    if (rechitMap.count(rechit.detid())) {
+      eeRecHits->push_back(rechit);
+    }
+  }
+  
+  for (const EcalRecHit &rechit : *preshowerHitHandle) {
+    if (rechitMap.count(rechit.detid())) {
+      esRecHits->push_back(rechit);
+    }
+  }
+  
+  theEvent.put(ebRecHits,outEBRecHits_);
+  theEvent.put(eeRecHits,outEERecHits_);
+  theEvent.put(esRecHits,outESRecHits_);  
+  
+  
+  //CaloClusters
+  //put calocluster output collections in event and get orphan handles to create ptrs
+  const edm::OrphanHandle<reco::CaloClusterCollection> &outEBEEClusterHandle = theEvent.put(ebeeClusters,outEBEEClusters_);
+  const edm::OrphanHandle<reco::CaloClusterCollection> &outESClusterHandle = theEvent.put(esClusters,outESClusters_);;  
+  
+  //loop over output superclusters and relink to output caloclusters
+  for (reco::SuperCluster &superCluster : *superClusters) {
+    //remap seed cluster
+    const auto &seedmapped = ebeeClusterMap.find(superCluster.seed());
+    if (seedmapped != ebeeClusterMap.end()) {
+      //make new ptr
+      reco::CaloClusterPtr clusptr(outEBEEClusterHandle,seedmapped->second);
+      superCluster.setSeed(clusptr);
+    }
+    
+    //remap all clusters
+    reco::CaloClusterPtrVector clusters;
+    for (const reco::CaloClusterPtr &cluster : superCluster.clusters()) {
+      const auto &clustermapped = ebeeClusterMap.find(cluster);
+      if (clustermapped != ebeeClusterMap.end()) {
+        //make new ptr
+        reco::CaloClusterPtr clusptr(outEBEEClusterHandle,clustermapped->second);
+        clusters.push_back(clusptr);
+      }
+      else {
+        //can only relink if all clusters are being relinked, so if one is missing, then skip the relinking completely
+        clusters.clear();
+        break;
+      }
+    }
+    if (clusters.size()) {
+      superCluster.setClusters(clusters);
+    }
+    
+    //remap preshower clusters
+    reco::CaloClusterPtrVector esclusters;
+    for (const reco::CaloClusterPtr &cluster : superCluster.preshowerClusters()) {
+      const auto &clustermapped = esClusterMap.find(cluster);
+      if (clustermapped != esClusterMap.end()) {
+        //make new ptr
+        reco::CaloClusterPtr clusptr(outESClusterHandle,clustermapped->second);
+        esclusters.push_back(clusptr);
+      }
+      else {
+        //can only relink if all clusters are being relinked, so if one is missing, then skip the relinking completely
+        esclusters.clear();
+        break;
+      }
+    }
+    if (esclusters.size()) {
+      superCluster.setPreshowerClusters(esclusters);
+    }
+    
+  }
+  
+  //put superclusters and conversions in the event
+  const edm::OrphanHandle<reco::SuperClusterCollection> &outSuperClusterHandle = theEvent.put(superClusters,outSuperClusters_);
+  const edm::OrphanHandle<reco::ConversionCollection> &outConversionHandle = theEvent.put(conversions,outConversions_);
+  const edm::OrphanHandle<reco::ConversionCollection> &outSingleConversionHandle = theEvent.put(singleConversions,outSingleConversions_);
+  
+  //loop over photoncores and relink superclusters (and conversions)
+  for (reco::PhotonCore &photonCore : *photonCores) {
+    const auto &scmapped = superClusterMap.find(photonCore.superCluster());
+    if (scmapped != superClusterMap.end()) {
+      //make new ref
+      reco::SuperClusterRef scref(outSuperClusterHandle,scmapped->second);
+      photonCore.setSuperCluster(scref);
+    }
+    
+    //conversions
+    const reco::ConversionRefVector &convrefs = photonCore.conversions();
+    reco::ConversionRefVector outconvrefs;
+    for (const reco::ConversionRef &convref : convrefs) {
+      const auto &convmapped = conversionMap.find(convref);
+      if (convmapped != conversionMap.end()) {
+        //make new ref
+        reco::ConversionRef outref(outConversionHandle,convmapped->second);
+      }
+      else {
+        //can only relink if all conversions are being relinked, so if one is missing, then skip the relinking completely
+        outconvrefs.clear();
+        break;
+      }
+    }
+    if (outconvrefs.size()) {
+      photonCore.setConversions(outconvrefs);
+    }
+    
+    //single leg conversions
+    const reco::ConversionRefVector &singleconvrefs = photonCore.conversionsOneLeg();
+    reco::ConversionRefVector outsingleconvrefs;
+    for (const reco::ConversionRef &convref : singleconvrefs) {
+      const auto &convmapped = singleConversionMap.find(convref);
+      if (convmapped != singleConversionMap.end()) {
+        //make new ref
+        reco::ConversionRef outref(outSingleConversionHandle,convmapped->second);
+      }
+      else {
+        //can only relink if all conversions are being relinked, so if one is missing, then skip the relinking completely
+        outsingleconvrefs.clear();
+        break;
+      }
+    }
+    if (outsingleconvrefs.size()) {
+      photonCore.setConversionsOneLeg(outsingleconvrefs);
+    }    
+    
+  }
+  
+  //loop over gsfelectroncores and relink superclusters
+  for (reco::GsfElectronCore &gsfElectronCore : *gsfElectronCores) {
+    const auto &scmapped = superClusterMap.find(gsfElectronCore.superCluster());
+    if (scmapped != superClusterMap.end()) {
+      //make new ref
+      reco::SuperClusterRef scref(outSuperClusterHandle,scmapped->second);
+      gsfElectronCore.setSuperCluster(scref);
+    }
+  }
+  
+  //put photon and gsfelectroncores into the event
+  const edm::OrphanHandle<reco::PhotonCoreCollection> &outPhotonCoreHandle = theEvent.put(photonCores,outPhotonCores_);
+  const edm::OrphanHandle<reco::GsfElectronCoreCollection> &outgsfElectronCoreHandle = theEvent.put(gsfElectronCores,outGsfElectronCores_);
+  
+  //loop over photons and electrons and relink the cores
+  for (reco::Photon &photon : *photons) {
+    const auto &coremapped = photonCoreMap.find(photon.photonCore());
+    if (coremapped != photonCoreMap.end()) {
+      //make new ref
+      reco::PhotonCoreRef coreref(outPhotonCoreHandle,coremapped->second);
+      photon.setPhotonCore(coreref);
+    }
+  }
+
+  for (reco::GsfElectron &gsfElectron : *gsfElectrons) {
+    const auto &coremapped = gsfElectronCoreMap.find(gsfElectron.core());
+    if (coremapped != gsfElectronCoreMap.end()) {
+      //make new ref
+      reco::GsfElectronCoreRef coreref(outgsfElectronCoreHandle,coremapped->second);
+      gsfElectron.setCore(coreref);
+    }
+  }
+  
+  //(finally) store the output photon and electron collections
+  const edm::OrphanHandle<reco::PhotonCollection> &outPhotonHandle = theEvent.put(photons,outPhotons_);  
+  const edm::OrphanHandle<reco::GsfElectronCollection> &outGsfElectronHandle = theEvent.put(gsfElectrons,outGsfElectrons_);
+  
+  //still need to output relinked valuemaps
+  
+  //photon pfcand isolation valuemap
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerPhotons(*photonPfCandMap);
+  fillerPhotons.insert(outPhotonHandle,pfCandIsoPairVecPho.begin(),pfCandIsoPairVecPho.end());
+  fillerPhotons.fill();   
+  
+  //electron pfcand isolation valuemap
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerGsfElectrons(*gsfElectronPfCandMap);
+  fillerGsfElectrons.insert(outGsfElectronHandle,pfCandIsoPairVecEle.begin(),pfCandIsoPairVecEle.end());
+  fillerGsfElectrons.fill();
+  
+  theEvent.put(photonPfCandMap,outPhotonPfCandMap_);
+  theEvent.put(gsfElectronPfCandMap,outGsfElectronPfCandMap_);
+  
+  //photon id value maps
+  for (unsigned int iid=0; iid<photonIds.size(); ++iid) {
+    edm::ValueMap<bool>::Filler fillerPhotonId(*photonIds[iid]);
+    fillerPhotonId.insert(outPhotonHandle,photonIdVals[iid].begin(),photonIdVals[iid].end());
+    fillerPhotonId.fill();
+    theEvent.put(photonIds[iid],outPhotonIds_[iid]);
+  }
+  
+  //electron id value maps
+  for (unsigned int iid=0; iid<gsfElectronIds.size(); ++iid) {
+    edm::ValueMap<float>::Filler fillerGsfElectronId(*gsfElectronIds[iid]);
+    fillerGsfElectronId.insert(outGsfElectronHandle,gsfElectronIdVals[iid].begin(),gsfElectronIdVals[iid].end());
+    fillerGsfElectronId.fill();
+    theEvent.put(gsfElectronIds[iid],outGsfElectronIds_[iid]);
+  }  
+  
+}
+
+

--- a/RecoEgamma/EgammaPhotonProducers/src/SealModule.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/SealModule.cc
@@ -11,6 +11,7 @@
 #include "RecoEgamma/EgammaPhotonProducers/interface/ConversionTrackMerger.h"
 #include "RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonCoreProducer.h"
 #include "RecoEgamma/EgammaPhotonProducers/interface/GEDPhotonProducer.h"
+#include "RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h"
 
 DEFINE_FWK_MODULE(PhotonCoreProducer);
 DEFINE_FWK_MODULE(PhotonProducer);
@@ -22,3 +23,4 @@ DEFINE_FWK_MODULE(ConversionTrackProducer);
 DEFINE_FWK_MODULE(ConversionTrackMerger);
 DEFINE_FWK_MODULE(GEDPhotonCoreProducer);
 DEFINE_FWK_MODULE(GEDPhotonProducer);
+DEFINE_FWK_MODULE(ReducedEGProducer);

--- a/RecoEgamma/EgammaTools/interface/ConversionTools.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionTools.h
@@ -41,7 +41,7 @@ class ConversionTools
                                                 
     static bool                        isGoodConversion(const reco::Conversion &conv, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
     
-    static bool                        matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch=true);
+    static bool                        matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch=true, bool allowAmbiguousGsfMatch=false);
     static bool                        matchesConversion(const reco::SuperCluster &sc, const reco::Conversion &conv, float dRMax = 0.1, float dEtaMax = 999., float dPhiMax = 999.);
     static bool                        matchesConversion(const edm::RefToBase<reco::Track> &trk, const reco::Conversion &conv);
     static bool                        matchesConversion(const reco::TrackRef &trk, const reco::Conversion &conv);

--- a/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
+++ b/RecoEgamma/EgammaTools/interface/EGEnergyCorrector.h
@@ -15,9 +15,9 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoEgamma/EgammaTools/interface/EcalClusterLocal.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
 class GBRForest;
-class EcalClusterLazyTools;
 
 class EGEnergyCorrector {
   public:

--- a/RecoEgamma/EgammaTools/src/ConversionTools.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionTools.cc
@@ -47,7 +47,7 @@ bool ConversionTools::isGoodConversion(const Conversion &conv, const math::XYZPo
 }
 
 //--------------------------------------------------------------------------------------------------
-bool ConversionTools::matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch)
+bool ConversionTools::matchesConversion(const reco::GsfElectron &ele, const reco::Conversion &conv, bool allowCkfMatch, bool allowAmbiguousGsfMatch)
 {
 
   //check if a given GsfElectron matches a given conversion (no quality cuts applied)
@@ -56,8 +56,13 @@ bool ConversionTools::matchesConversion(const reco::GsfElectron &ele, const reco
 
   const std::vector<edm::RefToBase<reco::Track> > &convTracks = conv.tracks();
   for (std::vector<edm::RefToBase<reco::Track> >::const_iterator it=convTracks.begin(); it!=convTracks.end(); ++it) {
-    if ( ele.gsfTrack().isNonnull() && ele.gsfTrack().id()==it->id() && ele.gsfTrack().key()==it->key()) return true;
-    else if ( allowCkfMatch && ele.closestCtfTrackRef().isNonnull() && ele.closestCtfTrackRef().id()==it->id() && ele.closestCtfTrackRef().key()==it->key() ) return true;
+    if ( ele.reco::GsfElectron::gsfTrack().isNonnull() && ele.reco::GsfElectron::gsfTrack().id()==it->id() && ele.reco::GsfElectron::gsfTrack().key()==it->key()) return true;
+    else if ( allowCkfMatch && ele.reco::GsfElectron::closestCtfTrackRef().isNonnull() && ele.reco::GsfElectron::closestCtfTrackRef().id()==it->id() && ele.reco::GsfElectron::closestCtfTrackRef().key()==it->key() ) return true;
+    if (allowAmbiguousGsfMatch) {
+      for (reco::GsfTrackRefVector::const_iterator tk = ele.ambiguousGsfTracksBegin(); tk!=ele.ambiguousGsfTracksEnd(); ++tk) {
+        if (tk->isNonnull() && tk->id()==it->id() && tk->key()==it->key()) return true;
+      }
+    }
   }
 
   return false;
@@ -299,7 +304,7 @@ bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc, 
   
   for (GsfElectronCollection::const_iterator it = eleCol->begin(); it!=eleCol->end(); ++it) {
     //match electron to supercluster
-    if (it->superCluster()!=sc) continue;
+    if (it->reco::GsfElectron::superCluster()!=sc) continue;
 
     //check expected inner hits
     if (it->gsfTrack()->trackerExpectedHitsInner().numberOfHits()>0) continue;
@@ -331,7 +336,7 @@ reco::GsfElectronRef ConversionTools::matchedPromptElectron(const reco::SuperClu
   
   for (GsfElectronCollection::const_iterator it = eleCol->begin(); it!=eleCol->end(); ++it) {
     //match electron to supercluster
-    if (it->superCluster()!=sc) continue;
+    if (it->reco::GsfElectron::superCluster()!=sc) continue;
 
     //check expected inner hits
     if (it->gsfTrack()->trackerExpectedHitsInner().numberOfHits()>0) continue;

--- a/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
+++ b/RecoEgamma/EgammaTools/src/EGEnergyCorrector.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 


### PR DESCRIPTION
Implement a comprehensive slimming and relinking of electron and photon collections through a dedicated producer.  This removes the duplication of embedded cluster information between electrons and photons.

Reduced conversion collections (with loose matching) are also produced.

Stored information is not exactly the same as before (can be tweaked further).

Current selection is
 keepPhotons = cms.string("pt > 14 && hadTowOverEm()<0.15"),
 relinkPhotons = cms.string("(r9()>0.8 || chargedHadronIso()<20 || chargedHadronIso()<0.3*pt())"),
 keepGsfElectrons = cms.string(""),
 relinkGsfElectrons = cms.string("pt>5"),

The "keep" selections control which objects are stored.  The "relink" selections control for which objects the dependent clusters/rechits/conversions are to be stored in the associated reduced collections and refs relinked.

Contrary to before, the SuperCluster and seed cluster are only included if the "relink" selection is passed.  (The last configuration for embedding was keeping these for all.)

There is additional information being stored through the conversions, and also the preshower clusters/rechits which were not included previously in the embedding.  (Can be discussed if this is really needed).

Net effect on event size is a minor (1.5% total) reduction for ttbar and essentially no change for jetHT data.  (Attached are edmEventSize dumps)

(I see that it won't merge automatically due to the last change in the configs, will rebase it tomorrow)
