### PR TITLE
adding hltPFHT

### DIFF
--- a/VHbbAnalysis/Heppy/python/TriggerObjectsList.py
+++ b/VHbbAnalysis/Heppy/python/TriggerObjectsList.py
@@ -17,6 +17,7 @@ triggerObjectCollectionsOnlyPt = {
     "caloMhtNoPU":[["hltMHTNoPU"]],
     "pfMet":[["hltPFMETProducer"]],
     "pfMht":[["hltPFMHTTightID"]],
+    "pfHt":[["hltPFHT"]],
 }
 triggerObjectCollectionsOnlySize = {
     ## VBF triggers


### PR DESCRIPTION
It adds the hltPFHT into the saved trigger objects.

http://cmslxr.fnal.gov/source/HLTrigger/Configuration/python/HLT_25ns14e33_v4_cff.py?v=CMSSW_7_6_1#31080
